### PR TITLE
Loosen engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "gulp test"
   },
   "engines": {
-    "node": "4.1.1"
+     "node": ">=4.1.1 <7.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "gulp test"
   },
   "engines": {
-     "node": ">=4.1.1 <7.0.0"
+    "node": ">=4.1.1 <7.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This package requires Node 4.1.1 specifically (https://github.com/Wildhoney/ngDroplet/blob/a59ea0cec934d5101866fd4266b159bfeca7be56/package.json#L10), meaning we have to run Yarn with the `--ignore-engines` flag to keep it from complaining.

As far as I can see, there are no BC breaks between 4.1.1 and 6.* that would break the example server.